### PR TITLE
switch add_filter priority and args from 1, 99 to 99, 1

### DIFF
--- a/uf2.php
+++ b/uf2.php
@@ -111,7 +111,7 @@ function uf2_the_title( $title ) {
   
   return $title;
 } 
-add_filter( 'the_title', 'uf2_the_title', 1, 99 );
+add_filter( 'the_title', 'uf2_the_title', 99, 1 );
 
 /**
  * Adds microformats v2 support to the post.
@@ -123,7 +123,7 @@ function uf2_the_post( $post ) {
   
   return $post;
 } 
-add_filter( 'the_content', 'uf2_the_post', 1, 99 );
+add_filter( 'the_content', 'uf2_the_post', 99, 1 );
 
 /**
  * Adds microformats v2 support to the comment.
@@ -135,7 +135,7 @@ function uf2_comment_text( $comment ) {
   
   return $comment;
 } 
-add_filter( 'comment_text', 'uf2_comment_text', 1, 99 );
+add_filter( 'comment_text', 'uf2_comment_text', 99, 1 );
 
 /**
  * Adds microformats v2 support to the excerpt.
@@ -147,7 +147,7 @@ function uf2_the_excerpt( $post ) {
   
   return $post;
 } 
-add_filter( 'the_excerpt', 'uf2_the_excerpt', 1, 99 );
+add_filter( 'the_excerpt', 'uf2_the_excerpt', 99, 1 );
 
 /**
  * Adds microformats v2 support to the author.
@@ -159,4 +159,4 @@ function uf2_the_author( $author ) {
   
   return $author;
 } 
-add_filter( 'the_author', 'uf2_the_author', 1, 99 );
+add_filter( 'the_author', 'uf2_the_author', 99, 1 );


### PR DESCRIPTION
hi matthias! thanks for writing uf2, i'm looking forward to using it. i'd use SemPress, but i already have another theme set up that i'm happy with, so i'm planning to use this to add microformats2 without changing themes.

i _think_ this bug fix is what you meant with the add_filter() calls, based on the add_filter docs (http://codex.wordpress.org/Function_Reference/add_filter#Parameters ). it fixes interaction with another plugin i use that also uses the the_content filter.

thanks in advance!
