### PR TITLE
add u-url, dt-published, and dt-updated to posts and comments in hidden blocks

### DIFF
--- a/uf2.php
+++ b/uf2.php
@@ -118,7 +118,15 @@ add_filter( 'the_title', 'uf2_the_title', 99, 1 );
  */
 function uf2_the_post( $post ) {
   if (!is_admin()) {
-    return "<div class='e-content'>$post</div>";
+    return "<div class='e-content'>$post</div>" .
+        "<div style='display: none'>\n" .
+        "<a class='u-url' href='" . get_permalink() . "'>" . get_the_title() .
+          "</a>\n" .
+        "<time class='dt-published' datetime='" . get_the_time("c") .
+          "'>" . get_the_time("r") . "</time>\n" .
+        "<time class='dt-updated' datetime='" . get_the_modified_time("c") .
+          "'>" . get_the_modified_time("r") . "</time>\n".
+        "</div>";
   }
 
   return $post;
@@ -130,7 +138,13 @@ add_filter( 'the_content', 'uf2_the_post', 99, 1 );
  */
 function uf2_comment_text( $comment ) {
   if (!is_admin()) {
-    return "<div class='e-content p-name p-summary'>$comment</div>";
+    return "<div class='e-content'>$comment</div>\n" .
+        "<div style='display: none'>\n" .
+        "<a class='u-url p-name p-summary' href='" . get_comment_link() . "'>" .
+          get_comment_excerpt() . "</a>\n" .
+        "<time class='dt-published' datetime='" . get_comment_time("c") . "'>" .
+          get_comment_time("r") . "</time>\n" .
+        "</div>";
   }
 
   return $comment;


### PR DESCRIPTION
one thing to note is that this changes comments' p-name and p-summary to be just an excerpt, by default the first 20 words, instead of the entire comment. that's probably what we want, but if not, that's ok.

you can see an example of this here: http://snarfed.org/2013-10-23_oauth-dropins

thanks in advance!
