### PR TITLE
move h-entry from body to article on single-post pages

### DIFF
--- a/uf2.php
+++ b/uf2.php
@@ -12,11 +12,7 @@
  * Adds custom classes to the array of post classes.
  */
 function uf2_post_classes( $classes ) {
-  if (!is_singular()) {
-    return uf2_post_classes_helper($classes);
-  }
-
-  return $classes;
+  return uf2_post_classes_helper($classes);
 }
 add_filter( 'post_class', 'uf2_post_classes' );
 
@@ -26,10 +22,7 @@ add_filter( 'post_class', 'uf2_post_classes' );
 function uf2_body_classes( $classes ) {
   if (!is_singular()) {
     $classes[] = "h-feed";
-  } else {
-    $classes = uf2_post_classes_helper($classes);
   }
-
   return $classes;
 }
 add_filter( 'body_class', 'uf2_body_classes' );


### PR DESCRIPTION
this is the final change to make php-mf2 happy. combined with the child theme parts i mentioned in the other pull request, it seems to be parsing ok. here are a couple examples:

single page:
http://pin13.net/mf2/?url=http%3A%2F%2Fsnarfed.org%2F2013-10-23_oauth-dropins

feed:
http://pin13.net/mf2/?url=http%3A%2F%2Fsnarfed.org%2F
