### PR TITLE
remove hentry from <article> in single posts, otherwise move it after h-entry

### DIFF
--- a/uf2.php
+++ b/uf2.php
@@ -14,6 +14,8 @@
 function uf2_post_classes( $classes ) {
   if (!is_singular()) {
     return uf2_post_classes_helper($classes);
+  } else {
+    $classes = array_diff($classes, array('hentry'));
   }
 
   return $classes;
@@ -47,7 +49,9 @@ add_filter( 'comment_class', 'uf2_comment_classes' );
 
 function uf2_post_classes_helper($classes) {
   // Adds a class for microformats v2
+  $classes = array_diff($classes, array('hentry'));
   $classes[] = 'h-entry';
+  $classes[] = 'hentry';
 
   // adds microformats 2 activity-stream support
   // for pages and articles


### PR DESCRIPTION
based on https://github.com/pfefferle/SemPress/commit/b137feb771c3a1de1393bdcbee6d28b1bd91109f

here are examples. the h-feed name in the scond is ugly, but that's my site's fault. otherwise everything looks good to me.

http://pin13.net/mf2/?url=http%3A%2F%2Fsnarfed.org%2F2013-10-23_oauth-dropins
http://pin13.net/mf2/?url=http%3A%2F%2Fsnarfed.org%2F
