### PR TITLE
add custom support for genesis themes

### DIFF
--- a/genesis.php
+++ b/genesis.php
@@ -7,32 +7,30 @@
 
 add_action( 'init', 'uf2_genesis_init' );
 function uf2_genesis_init() {
-  if ( function_exists( 'genesis_html5' ) && genesis_html5() ) {
-    // replace some post hooks
-    remove_filter( 'the_title', 'uf2_the_title', 99, 1 );
-    remove_filter( 'the_content', 'uf2_the_post', 99, 1 );
-    remove_filter( 'the_excerpt', 'uf2_the_excerpt', 99, 1 );
-    remove_filter( 'the_author', 'uf2_the_author', 99, 1 );
+  // replace some post hooks
+  remove_filter( 'the_title', 'uf2_the_title', 99, 1 );
+  remove_filter( 'the_content', 'uf2_the_post', 99, 1 );
+  remove_filter( 'the_excerpt', 'uf2_the_excerpt', 99, 1 );
+  remove_filter( 'the_author', 'uf2_the_author', 99, 1 );
 
-    add_filter( 'genesis_entry_header', 'uf2_genesis_entry_permalink' );
-    add_filter( 'genesis_attr_entry-title', 'uf2_genesis_attr_entry_title', 20 );
-    add_filter( 'genesis_attr_entry-content', 'uf2_genesis_attr_entry_content', 20 );
-    add_filter( 'genesis_attr_entry-time', 'uf2_genesis_attr_entry_time', 20 );
-    add_filter( 'genesis_attr_entry-author', 'uf2_genesis_attr_entry_author', 20 );
-    add_filter( 'genesis_attr_entry-author-link', 'uf2_genesis_attr_entry_author_link', 20 );
-    add_filter( 'genesis_attr_entry-author-name', 'uf2_genesis_attr_entry_author_name', 20 );
+  add_filter( 'genesis_entry_header', 'uf2_genesis_entry_permalink' );
+  add_filter( 'genesis_attr_entry-title', 'uf2_genesis_attr_entry_title', 20 );
+  add_filter( 'genesis_attr_entry-content', 'uf2_genesis_attr_entry_content', 20 );
+  add_filter( 'genesis_attr_entry-time', 'uf2_genesis_attr_entry_time', 20 );
+  add_filter( 'genesis_attr_entry-author', 'uf2_genesis_attr_entry_author', 20 );
+  add_filter( 'genesis_attr_entry-author-link', 'uf2_genesis_attr_entry_author_link', 20 );
+  add_filter( 'genesis_attr_entry-author-name', 'uf2_genesis_attr_entry_author_name', 20 );
 
-    // replace some comment hooks
-    remove_filter( 'comment_text', 'uf2_comment_text', 99, 1 );
-    remove_filter( 'get_comment_author_link', 'uf2_author_link' );
-    remove_filter( 'comment_class', 'uf2_comment_classes' );
+  // replace some comment hooks
+  remove_filter( 'comment_text', 'uf2_comment_text', 99, 1 );
+  remove_filter( 'get_comment_author_link', 'uf2_author_link' );
+  remove_filter( 'comment_class', 'uf2_comment_classes' );
 
-    add_filter( 'genesis_attr_comment', 'uf2_genesis_attr_comment', 20 );
-    add_filter( 'genesis_attr_comment-author', 'uf2_genesis_attr_comment_author', 20 );
+  add_filter( 'genesis_attr_comment', 'uf2_genesis_attr_comment', 20 );
+  add_filter( 'genesis_attr_comment-author', 'uf2_genesis_attr_comment_author', 20 );
 
-    // additional hooks
-    add_filter( 'genesis_attr_site-title', 'uf2_genesis_attr_site_title' );
-  }
+  // additional hooks
+  add_filter( 'genesis_attr_site-title', 'uf2_genesis_attr_site_title' );
 }
 
 /**

--- a/uf2.php
+++ b/uf2.php
@@ -8,7 +8,9 @@
  Version: 1.0.0-dev
 */
 
-include_once dirname(__FILE__) . '/genesis.php';
+if ( function_exists( 'genesis_html5' ) && genesis_html5() ) {
+  include_once dirname(__FILE__) . '/genesis.php';
+}
 
 /**
  * Adds custom classes to the array of post classes.


### PR DESCRIPTION
A couple of months ago, I switched to use [Genesis](http://my.studiopress.com/themes/genesis/) on my personal site.  One of the things I really like about it is that it is incredibly extensible, with hooks to modify the attributes of various elements throughout the theme.  This actually allows for a much cleaner approach to adding microformats, since you don't need to use wrapper divs.

I was hesitant to send this as a pull request at all, since I'm not sure if it really makes sense to add such custom support for one particular theme framework.  But I figured I'd at least send it your way and see what you thought.  For what it's worth, this is at least well behaved in the sense that it only loads genesis.php if genesis is active.
