### PR TITLE
fix genesis support

### DIFF
--- a/genesis.php
+++ b/genesis.php
@@ -5,33 +5,15 @@
  * those hooks when Genesis is present.
  */
 
-add_action( 'init', 'uf2_genesis_init' );
-function uf2_genesis_init() {
-  // replace some post hooks
-  remove_filter( 'the_title', 'uf2_the_title', 99, 1 );
-  remove_filter( 'the_content', 'uf2_the_post', 99, 1 );
-  remove_filter( 'the_excerpt', 'uf2_the_excerpt', 99, 1 );
-  remove_filter( 'the_author', 'uf2_the_author', 99, 1 );
+// replace some post and comment hooks
+remove_filter( 'the_title', 'uf2_the_title', 99, 1 );
+remove_filter( 'the_content', 'uf2_the_post', 99, 1 );
+remove_filter( 'the_excerpt', 'uf2_the_excerpt', 99, 1 );
+remove_filter( 'the_author', 'uf2_the_author', 99, 1 );
+remove_filter( 'comment_text', 'uf2_comment_text', 99, 1 );
+remove_filter( 'get_comment_author_link', 'uf2_author_link' );
+remove_filter( 'comment_class', 'uf2_comment_classes' );
 
-  add_filter( 'genesis_entry_header', 'uf2_genesis_entry_permalink' );
-  add_filter( 'genesis_attr_entry-title', 'uf2_genesis_attr_entry_title', 20 );
-  add_filter( 'genesis_attr_entry-content', 'uf2_genesis_attr_entry_content', 20 );
-  add_filter( 'genesis_attr_entry-time', 'uf2_genesis_attr_entry_time', 20 );
-  add_filter( 'genesis_attr_entry-author', 'uf2_genesis_attr_entry_author', 20 );
-  add_filter( 'genesis_attr_entry-author-link', 'uf2_genesis_attr_entry_author_link', 20 );
-  add_filter( 'genesis_attr_entry-author-name', 'uf2_genesis_attr_entry_author_name', 20 );
-
-  // replace some comment hooks
-  remove_filter( 'comment_text', 'uf2_comment_text', 99, 1 );
-  remove_filter( 'get_comment_author_link', 'uf2_author_link' );
-  remove_filter( 'comment_class', 'uf2_comment_classes' );
-
-  add_filter( 'genesis_attr_comment', 'uf2_genesis_attr_comment', 20 );
-  add_filter( 'genesis_attr_comment-author', 'uf2_genesis_attr_comment_author', 20 );
-
-  // additional hooks
-  add_filter( 'genesis_attr_site-title', 'uf2_genesis_attr_site_title' );
-}
 
 /**
  * Markup site title as p-name on archive pages.
@@ -42,6 +24,7 @@ function uf2_genesis_attr_site_title($attr) {
   }
   return $attr;
 }
+add_filter( 'genesis_attr_site-title', 'uf2_genesis_attr_site_title' );
 
 /**
  * Add entry permalink with microformats 2 support.  This is a little ugly
@@ -52,6 +35,7 @@ function uf2_genesis_attr_site_title($attr) {
 function uf2_genesis_entry_permalink() {
   echo '<a class="u-url" href="' . get_permalink() .'"></a>';
 }
+add_filter( 'genesis_entry_header', 'uf2_genesis_entry_permalink' );
 
 /**
  * Adds microformats v2 support to the post title.
@@ -60,6 +44,7 @@ function uf2_genesis_attr_entry_title( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'p-name';
   return $attr;
 }
+add_filter( 'genesis_attr_entry-title', 'uf2_genesis_attr_entry_title', 20 );
 
 /**
  * Adds microformats v2 support to the post content.
@@ -68,6 +53,7 @@ function uf2_genesis_attr_entry_content( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'e-content';
   return $attr;
 }
+add_filter( 'genesis_attr_entry-content', 'uf2_genesis_attr_entry_content', 20 );
 
 /**
  * Adds microformats v2 support to the post date.
@@ -76,6 +62,7 @@ function uf2_genesis_attr_entry_time( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'dt-published';
   return $attr;
 }
+add_filter( 'genesis_attr_entry-time', 'uf2_genesis_attr_entry_time', 20 );
 
 /**
  * Adds microformats v2 support to the post author.
@@ -84,6 +71,7 @@ function uf2_genesis_attr_entry_author( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'p-author h-card';
   return $attr;
 }
+add_filter( 'genesis_attr_entry-author', 'uf2_genesis_attr_entry_author', 20 );
 
 /**
  * Adds microformats v2 support to the post author link.
@@ -92,6 +80,7 @@ function uf2_genesis_attr_entry_author_link( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'u-url';
   return $attr;
 }
+add_filter( 'genesis_attr_entry-author-link', 'uf2_genesis_attr_entry_author_link', 20 );
 
 /**
  * Adds microformats v2 support to the post author name.
@@ -100,6 +89,7 @@ function uf2_genesis_attr_entry_author_name( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'p-name';
   return $attr;
 }
+add_filter( 'genesis_attr_entry-author-name', 'uf2_genesis_attr_entry_author_name', 20 );
 
 /**
  * Adds microformat 2 classes to the array of comment classes.
@@ -108,6 +98,7 @@ function uf2_genesis_attr_comment( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'p-comment h-entry';
   return $attr;
 }
+add_filter( 'genesis_attr_comment', 'uf2_genesis_attr_comment', 20 );
 
 /**
  * Adds microformats v2 support to the comment author.
@@ -116,4 +107,5 @@ function uf2_genesis_attr_comment_author( $attr ) {
   $attr['class'] .= ( $attr['class'] ? ' ' : '' ) . 'p-author h-card';
   return $attr;
 }
+add_filter( 'genesis_attr_comment-author', 'uf2_genesis_attr_comment_author', 20 );
 

--- a/uf2.php
+++ b/uf2.php
@@ -8,7 +8,8 @@
  Version: 1.0.0-dev
 */
 
-if ( function_exists( 'genesis_html5' ) && genesis_html5() ) {
+add_action( 'init', 'uf2_genesis_init' );
+function uf2_genesis_init() {
   include_once dirname(__FILE__) . '/genesis.php';
 }
 


### PR DESCRIPTION
we can't call genesis_html5 directly from within uf2, since the plugin is
apparently loaded before the theme.  Instead, we move uf2_genesis_init
into the main uf2.php file, and then include genesis.php when needed.
