### PR TITLE
UF2_Post::the_post - add newlines, don't let e-content collide with Micropub's

### DIFF
--- a/includes/class-uf2-post.php
+++ b/includes/class-uf2-post.php
@@ -72,11 +72,12 @@ class UF2_Post {
 	 * Adds microformats v2 support to the post.
 	 */
 	public static function the_post( $post ) {
-		if ( ! is_admin() ) {
-			return "<div class='e-content'>$post</div>";
+		if ( ! is_admin() &&
+			 ! ( function_exists( 'is_micropub_post' ) && is_micropub_post() ) ) {
+			return "<div class='e-content'>\n$post\n</div>";
 		}
 
-		return $post;
+		return "\n" . $post . "\n";
 	}
 
 	/**


### PR DESCRIPTION
* if the Micropub plugin has already added `<div class="e-content">`, don't add it again
* add newlines before and after `$post` so that WordPress generates `<p>` and `</p>` tags correctly
    
for https://github.com/indieweb/wordpress-micropub/issues/294 and https://github.com/indieweb/wordpress-micropub/issues/298